### PR TITLE
Refactor v2.1.2

### DIFF
--- a/address_separator/interfaces/address.py
+++ b/address_separator/interfaces/address.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class AddressData:
     """ """
 

--- a/address_separator/utils/extract/city.py
+++ b/address_separator/utils/extract/city.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def extract_city(non_prefecture_address_data: list[str]) -> tuple[list[str], list[str]]:
     """
     市、区、群、町、村の順で文字列を探索し、分割する。

--- a/address_separator/utils/extract/detail/building_detail.py
+++ b/address_separator/utils/extract/detail/building_detail.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 

--- a/address_separator/utils/extract/detail/building_detail.py
+++ b/address_separator/utils/extract/detail/building_detail.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 
 
-def extract_building_detail(data: dict):
+def extract_building_detail(data: dict[str, list[str]]):
     # special_chractersのなかの F のみ抽出
     building_detail_info: list = []
 

--- a/address_separator/utils/extract/detail/building_detail.py
+++ b/address_separator/utils/extract/detail/building_detail.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 
 
-def extract_building_detail(data: dict[str, list[str]]):
+def extract_building_detail(splitted_address_data_dictionaries: dict[str, list[str]]):
     # special_chractersのなかの F のみ抽出
     building_detail_info: list = []
 
@@ -16,31 +16,37 @@ def extract_building_detail(data: dict[str, list[str]]):
 
     def cutting_number_from_last(index: int):
         """上記の関数と同時に使用する。8Fのように、建物の階数情報のみを抽出する"""
-        if re.search("-([0-9]+)$", data["house_number"][index]) is None:
+        if re.search("-([0-9]+)$", splitted_address_data_dictionaries["house_number"][index]) is None:
             print("something wrong1")  # for debug
         else:
 
             start: int = 0
             end: int = 0
 
-            regular_expression_start = re.search("-([0-9]+)$", data["house_number"][index])
+            regular_expression_start = re.search(
+                "-([0-9]+)$", splitted_address_data_dictionaries["house_number"][index]
+            )
             if regular_expression_start is not None:
                 start = regular_expression_start.start()
 
-            regular_expression_end = re.search("-([0-9]+)$", data["house_number"][index])
+            regular_expression_end = re.search("-([0-9]+)$", splitted_address_data_dictionaries["house_number"][index])
             if regular_expression_end is not None:
                 end = regular_expression_end.end()
 
-            if end != len(data["house_number"][index]):
+            if end != len(splitted_address_data_dictionaries["house_number"][index]):
                 print("index which driven by regular expression is something wrong.")  # for debug
             # start+1 にしているのは-{数字}Fとなっているので - を除いている
-            building_detail_info.append(data["house_number"][index][start + 1 : end] + "F")
-            data["house_number"][index] = data["house_number"][index][:start]
+            building_detail_info.append(
+                splitted_address_data_dictionaries["house_number"][index][start + 1 : end] + "F"
+            )
+            splitted_address_data_dictionaries["house_number"][index] = splitted_address_data_dictionaries[
+                "house_number"
+            ][index][:start]
 
-    for i in range(len(data["special_characters"])):
-        if find_F(data["special_characters"][i]):
+    for i in range(len(splitted_address_data_dictionaries["special_characters"])):
+        if find_F(splitted_address_data_dictionaries["special_characters"][i]):
             # 空白に変える
-            data["special_characters"][i] = ""
+            splitted_address_data_dictionaries["special_characters"][i] = ""
             # special_charactersから数字をfetch
             cutting_number_from_last(i)
         else:

--- a/address_separator/utils/extract/detail/check/caution.py
+++ b/address_separator/utils/extract/detail/check/caution.py
@@ -1,7 +1,7 @@
 import re
 
 
-def caution(data: dict, munipulated_others_tail: list, caution: list):
+def caution(data: dict[str, list[str]], munipulated_others_tail: list[str], caution: list[str]):
     """
     不適切な形で分割されていると思われるデータを検知し、cautionを出す。一部データ整形機能も持つ
     エラー文は、文字列を結合させていく方式で連結していく。

--- a/address_separator/utils/extract/detail/check/caution.py
+++ b/address_separator/utils/extract/detail/check/caution.py
@@ -1,7 +1,9 @@
 import re
 
 
-def caution(data: dict[str, list[str]], munipulated_others_tail: list[str], caution: list[str]):
+def caution(
+    splitted_address_data_dictionaries: dict[str, list[str]], munipulated_others_tail: list[str], caution: list[str]
+):
     """
     不適切な形で分割されていると思われるデータを検知し、cautionを出す。一部データ整形機能も持つ
     エラー文は、文字列を結合させていく方式で連結していく。
@@ -19,95 +21,102 @@ def caution(data: dict[str, list[str]], munipulated_others_tail: list[str], caut
     for i in range(len(munipulated_others_tail)):
         munipulated_others_tail[i] = replace_half_hypen_with_full_width_hypen(munipulated_others_tail[i])
 
-    data["building_info"] = munipulated_others_tail
-    data["building_detail_info"] = data["building_detail_info"]
-    data["error1"] = caution
-    data["error2"] = [""] * len(caution)
-    data["caution"] = [""] * len(caution)
+    splitted_address_data_dictionaries["building_info"] = munipulated_others_tail
+    splitted_address_data_dictionaries["building_detail_info"] = splitted_address_data_dictionaries[
+        "building_detail_info"
+    ]
+    splitted_address_data_dictionaries["error1"] = caution
+    splitted_address_data_dictionaries["error2"] = [""] * len(caution)
+    splitted_address_data_dictionaries["caution"] = [""] * len(caution)
     # caution: CAUTION, error1 深刻なエラー, error2 普通のエラー
     """ビル情報の列にビルの詳細情報の断片と思われるデータが存在するとき"""
-    for index in range(len(data["building_info"])):
-        if re.search("(^号)|(^号館)", data["building_info"][index]) is not None:
-            data["caution"][
+    for index in range(len(splitted_address_data_dictionaries["building_info"])):
+        if re.search("(^号)|(^号館)", splitted_address_data_dictionaries["building_info"][index]) is not None:
+            splitted_address_data_dictionaries["caution"][
                 index
             ] += "CAUTION: address4のデータは、address5にあるべきはずのデータを含んでいる場合があります。周辺のデータ分割が正しいかどうか確認することを推奨します.  "
         else:
             pass
     # cityにおかしなところがないか調査
-    for index in range(len(data["city"])):
-        if data["city"][index] == "":
+    for index in range(len(splitted_address_data_dictionaries["city"])):
+        if splitted_address_data_dictionaries["city"][index] == "":
             continue
-        if re.search("[ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠]+", data["city"][index]) is None:
+        if re.search("[ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠]+", splitted_address_data_dictionaries["city"][index]) is None:
             # 日本語が見つからない
-            data["error1"][index] += "ERROR: address1のデータには不正な文字列が含まれています。  "
+            splitted_address_data_dictionaries["error1"][index] += "ERROR: address1のデータには不正な文字列が含まれています。  "
         else:
             pass
     # townにおかしなところがないか調査
-    for index in range(len(data["town"])):
-        if data["town"][index] == "":
+    for index in range(len(splitted_address_data_dictionaries["town"])):
+        if splitted_address_data_dictionaries["town"][index] == "":
             continue
-        if re.search("[ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠]+", data["town"][index]) is None:
+        if re.search("[ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠]+", splitted_address_data_dictionaries["town"][index]) is None:
             # 日本語が見つからない
-            data["error1"][index] += "ERROR: address1または、address2のデータには不正な文字列が含まれています。  "
+            splitted_address_data_dictionaries["error1"][index] += "ERROR: address1または、address2のデータには不正な文字列が含まれています。  "
         else:
             pass
     # districtにおかしなところがないか調査
-    for index in range(len(data["district"])):
-        if data["district"][index] == "":
+    for index in range(len(splitted_address_data_dictionaries["district"])):
+        if splitted_address_data_dictionaries["district"][index] == "":
             continue
-        if re.search("[ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠]+", data["district"][index]) is None:
+        if re.search("[ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠]+", splitted_address_data_dictionaries["district"][index]) is None:
             # 日本語が見つからない
-            data["error1"][index] += "ERROR: address2のデータには不正な文字列が含まれています。  "
+            splitted_address_data_dictionaries["error1"][index] += "ERROR: address2のデータには不正な文字列が含まれています。  "
         else:
             pass
-    for index in range(len(data["house_number"])):
-        if data["house_number"][index] == "":
+    for index in range(len(splitted_address_data_dictionaries["house_number"])):
+        if splitted_address_data_dictionaries["house_number"][index] == "":
             continue
-        if re.search("[ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠]+", data["house_number"][index]) is not None:
+        if re.search("[ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠]+", splitted_address_data_dictionaries["house_number"][index]) is not None:
             # 日本語が見つかった
-            data["error1"][index] += "ERROR: address3のデータには不正な文字列が含まれています。  "
+            splitted_address_data_dictionaries["error1"][index] += "ERROR: address3のデータには不正な文字列が含まれています。  "
         else:
             pass
-    for index in range(len(data["special_characters"])):
-        if data["house_number"][index] == "":
+    for index in range(len(splitted_address_data_dictionaries["special_characters"])):
+        if splitted_address_data_dictionaries["house_number"][index] == "":
             continue
-        if re.search("[ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠]+", data["special_characters"][index]) is not None:
+        if re.search("[ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠]+", splitted_address_data_dictionaries["special_characters"][index]) is not None:
             # 日本語が見つかった
-            data["caution"][index] += "CAUTION: address4のデータには不正な文字列が含まれています。  "
+            splitted_address_data_dictionaries["caution"][index] += "CAUTION: address4のデータには不正な文字列が含まれています。  "
         else:
             pass
-    for index in range(len(data["original"])):
-        if data["original"][index] == "":
+    for index in range(len(splitted_address_data_dictionaries["original"])):
+        if splitted_address_data_dictionaries["original"][index] == "":
             continue
-        if re.search("[ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠]+", data["original"][index]) is None:
+        if re.search("[ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠]+", splitted_address_data_dictionaries["original"][index]) is None:
             # 日本語が見つからない
-            data["error1"][index] += "ERROR: 入力された元データに何らかの問題があります。入力されたデータを確認してください。  "
+            splitted_address_data_dictionaries["error1"][index] += "ERROR: 入力された元データに何らかの問題があります。入力されたデータを確認してください。  "
         else:
             pass
     # 不正なデータを検出
-    for index in range(len(data["town"])):
-        if data["town"][index] == "":
+    for index in range(len(splitted_address_data_dictionaries["town"])):
+        if splitted_address_data_dictionaries["town"][index] == "":
             continue
-        if re.search("[0-9]+", data["town"][index]) is not None:
+        if re.search("[0-9]+", splitted_address_data_dictionaries["town"][index]) is not None:
             # 半角算用数字がある
-            data["error1"][index] += "ERROR: address1のデータには存在しないはずのアラビア数字が含まれています。  "
+            splitted_address_data_dictionaries["error1"][index] += "ERROR: address1のデータには存在しないはずのアラビア数字が含まれています。  "
         else:
             pass
-    for index in range(len(data["district"])):
-        if data["district"][index] == "":
+    for index in range(len(splitted_address_data_dictionaries["district"])):
+        if splitted_address_data_dictionaries["district"][index] == "":
             continue
-        if re.search("[一-十]{2,}", data["district"][index]) is not None:
+        if re.search("[一-十]{2,}", splitted_address_data_dictionaries["district"][index]) is not None:
             # 日本語数字が2回以上続く、地名の可能性もあるが、高確率番地
-            data["error1"][index] += "CAUTION: address2のデータには不正な文字列が含まれている可能性があります。  "
+            splitted_address_data_dictionaries["error1"][index] += "CAUTION: address2のデータには不正な文字列が含まれている可能性があります。  "
         else:
             pass
     # building_info が空なのに building_detail_infoが空ではなかったらcaution
-    for index in range(len(data["building_info"])):
-        if data["building_info"][index] == "" and data["building_detail_info"][index] != "":
-            data["caution"][index] += "CAUTION: address4と、address5のデータには不正な文字列が含まれている可能性があります。両方について確認することを推奨します。  "
+    for index in range(len(splitted_address_data_dictionaries["building_info"])):
+        if (
+            splitted_address_data_dictionaries["building_info"][index] == ""
+            and splitted_address_data_dictionaries["building_detail_info"][index] != ""
+        ):
+            splitted_address_data_dictionaries["caution"][
+                index
+            ] += "CAUTION: address4と、address5のデータには不正な文字列が含まれている可能性があります。両方について確認することを推奨します。  "
     # 都道府県名が空欄ならcaution
-    for index in range(len(data["prefecture"])):
-        if data["prefecture"][index] == "":
-            data["error2"][
+    for index in range(len(splitted_address_data_dictionaries["prefecture"])):
+        if splitted_address_data_dictionaries["prefecture"][index] == "":
+            splitted_address_data_dictionaries["error2"][
                 index
             ] += "ERROR: prefectureの列の情報がありません。元データに都道府県情報が欠落している可能性があります。入力されたデータ形式は、自動チェック機構が推奨する形式ではありません。  "

--- a/address_separator/utils/extract/detail/check/check.py
+++ b/address_separator/utils/extract/detail/check/check.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 

--- a/address_separator/utils/extract/detail/check/check.py
+++ b/address_separator/utils/extract/detail/check/check.py
@@ -3,13 +3,23 @@ from __future__ import annotations
 import re
 
 
-def check(data: dict) -> list[str]:
+def check(data: dict, others_tail) -> list[str]:
     """
     cautionの配列を生成する
     """
 
     def check_vaild_word_or_not(index: int):
-        if re.search("^([0-9ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠])+$", data["invalid"][index]) is not None:
+        if re.search("^([0-9ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠-])+$", data["invalid"][index]) is not None:
+            # 愛知県名古屋市天白区天白町平針黒石２８４５平針住宅14-24
+            if re.search("^[0-9]{2,}", data["invalid"][index]) is not None:
+                match = re.search("^[0-9]{2,}", data["invalid"][index])
+                assert match is not None
+                string = data["invalid"][index]
+                if index is not None:
+                    others_tail[index] = string[match.end() :] + data["house_number"][index] + others_tail[index]
+                    data["house_number"][index] = string[0 : match.end()]
+                    data["invalid"][index] = ""
+
             mapping_arithmetic_number_to_japanese_number: dict = {
                 "1": "一",
                 "2": "二",

--- a/address_separator/utils/extract/detail/check/check.py
+++ b/address_separator/utils/extract/detail/check/check.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 
 
-def check(data: dict, others_tail: list[str]) -> list[str]:
+def check(data: dict[str, list[str]], others_tail: list[str]) -> list[str]:
     """
     cautionの配列を生成する
     """

--- a/address_separator/utils/extract/detail/check/check.py
+++ b/address_separator/utils/extract/detail/check/check.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 
 
-def check(data: dict, others_tail) -> list[str]:
+def check(data: dict, others_tail: list[str]) -> list[str]:
     """
     cautionの配列を生成する
     """

--- a/address_separator/utils/extract/detail/check/check.py
+++ b/address_separator/utils/extract/detail/check/check.py
@@ -3,24 +3,24 @@ from __future__ import annotations
 import re
 
 
-def check(splitted_address_data_dictionaries: dict, others_tail: list[str]) -> list[str]:
+def check(data: dict, others_tail: list[str]) -> list[str]:
     """
     cautionの配列を生成する
     """
 
-    def check_vaild_word_or_not(index: int):
-        if re.search("^([0-9ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠-])+$", splitted_address_data_dictionaries["invalid"][index]) is not None:
+    def check_valid_word_or_not(index: int):
+        if re.search("^([0-9ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠-])+$", data["invalid"][index]) is not None:
             # 愛知県名古屋市天白区天白町平針黒石２８４５平針住宅14-24
-            if re.search("^[0-9]{2,}", splitted_address_data_dictionaries["invalid"][index]) is not None:
-                match = re.search("^[0-9]{2,}", splitted_address_data_dictionaries["invalid"][index])
+            if re.search("^[0-9]{2,}", data["invalid"][index]) is not None:
+                match = re.search("^[0-9]{2,}", data["invalid"][index])
                 assert match is not None
-                string = splitted_address_data_dictionaries["invalid"][index]
+                invalid_word = data["invalid"][index]
                 if index is not None:
-                    others_tail[index] = string[match.end() :] + splitted_address_data_dictionaries["house_number"][index] + others_tail[index]
-                    splitted_address_data_dictionaries["house_number"][index] = string[0 : match.end()]
-                    splitted_address_data_dictionaries["invalid"][index] = ""
+                    others_tail[index] = invalid_word[match.end() :] + data["house_number"][index] + others_tail[index]
+                    data["house_number"][index] = invalid_word[0 : match.end()]
+                    data["invalid"][index] = ""
 
-            mapping_arithmetic_number_to_japanese_number: dict = {
+            MAPPING_ARITHMETIC_NUMBER_TO_JAPANESE_NUMBER: dict = {
                 "1": "一",
                 "2": "二",
                 "3": "三",
@@ -33,9 +33,9 @@ def check(splitted_address_data_dictionaries: dict, others_tail: list[str]) -> l
             }
             numbers: list = [str(i) for i in range(1, 10)]
             res: str = ""
-            for char in splitted_address_data_dictionaries["invalid"][index]:
+            for char in data["invalid"][index]:
                 if char in numbers:
-                    res = res + mapping_arithmetic_number_to_japanese_number[char]
+                    res = res + MAPPING_ARITHMETIC_NUMBER_TO_JAPANESE_NUMBER[char]
                 else:
                     res = res + char
             return res
@@ -43,15 +43,15 @@ def check(splitted_address_data_dictionaries: dict, others_tail: list[str]) -> l
             return ""
 
     caution: list = []
-    for index in range(len(splitted_address_data_dictionaries["invalid"])):
-        response: str = check_vaild_word_or_not(index)
-        if splitted_address_data_dictionaries["invalid"][index] == "":
+    for index in range(len(data["invalid"])):
+        response: str = check_valid_word_or_not(index)
+        if data["invalid"][index] == "":
             caution.append("")
         elif response == "":
             # 不正な文字列
             caution.append("ERROR: データは、整形不可能な状態です。自動整形システムは正しく動作しません。この行の全ての結果を確認することを推奨します。  ")
         else:
             caution.append("")
-            splitted_address_data_dictionaries["invalid"][index] = ""
-            splitted_address_data_dictionaries["district"][index] += response
+            data["invalid"][index] = ""
+            data["district"][index] += response
     return caution

--- a/address_separator/utils/extract/detail/check/check.py
+++ b/address_separator/utils/extract/detail/check/check.py
@@ -3,22 +3,22 @@ from __future__ import annotations
 import re
 
 
-def check(data: dict, others_tail: list[str]) -> list[str]:
+def check(splitted_address_data_dictionaries: dict, others_tail: list[str]) -> list[str]:
     """
     cautionの配列を生成する
     """
 
     def check_vaild_word_or_not(index: int):
-        if re.search("^([0-9ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠-])+$", data["invalid"][index]) is not None:
+        if re.search("^([0-9ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠-])+$", splitted_address_data_dictionaries["invalid"][index]) is not None:
             # 愛知県名古屋市天白区天白町平針黒石２８４５平針住宅14-24
-            if re.search("^[0-9]{2,}", data["invalid"][index]) is not None:
-                match = re.search("^[0-9]{2,}", data["invalid"][index])
+            if re.search("^[0-9]{2,}", splitted_address_data_dictionaries["invalid"][index]) is not None:
+                match = re.search("^[0-9]{2,}", splitted_address_data_dictionaries["invalid"][index])
                 assert match is not None
-                string = data["invalid"][index]
+                string = splitted_address_data_dictionaries["invalid"][index]
                 if index is not None:
-                    others_tail[index] = string[match.end() :] + data["house_number"][index] + others_tail[index]
-                    data["house_number"][index] = string[0 : match.end()]
-                    data["invalid"][index] = ""
+                    others_tail[index] = string[match.end() :] + splitted_address_data_dictionaries["house_number"][index] + others_tail[index]
+                    splitted_address_data_dictionaries["house_number"][index] = string[0 : match.end()]
+                    splitted_address_data_dictionaries["invalid"][index] = ""
 
             mapping_arithmetic_number_to_japanese_number: dict = {
                 "1": "一",
@@ -33,7 +33,7 @@ def check(data: dict, others_tail: list[str]) -> list[str]:
             }
             numbers: list = [str(i) for i in range(1, 10)]
             res: str = ""
-            for char in data["invalid"][index]:
+            for char in splitted_address_data_dictionaries["invalid"][index]:
                 if char in numbers:
                     res = res + mapping_arithmetic_number_to_japanese_number[char]
                 else:
@@ -43,15 +43,15 @@ def check(data: dict, others_tail: list[str]) -> list[str]:
             return ""
 
     caution: list = []
-    for index in range(len(data["invalid"])):
+    for index in range(len(splitted_address_data_dictionaries["invalid"])):
         response: str = check_vaild_word_or_not(index)
-        if data["invalid"][index] == "":
+        if splitted_address_data_dictionaries["invalid"][index] == "":
             caution.append("")
         elif response == "":
             # 不正な文字列
             caution.append("ERROR: データは、整形不可能な状態です。自動整形システムは正しく動作しません。この行の全ての結果を確認することを推奨します。  ")
         else:
             caution.append("")
-            data["invalid"][index] = ""
-            data["district"][index] += response
+            splitted_address_data_dictionaries["invalid"][index] = ""
+            splitted_address_data_dictionaries["district"][index] += response
     return caution

--- a/address_separator/utils/extract/detail/check/check.py
+++ b/address_separator/utils/extract/detail/check/check.py
@@ -3,22 +3,26 @@ from __future__ import annotations
 import re
 
 
-def check(data: dict[str, list[str]], others_tail: list[str]) -> list[str]:
+def check(splitted_address_data_dictionaries: dict[str, list[str]], others_tail: list[str]) -> list[str]:
     """
     cautionの配列を生成する
     """
 
     def check_valid_word_or_not(index: int):
-        if re.search("^([0-9ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠-])+$", data["invalid"][index]) is not None:
+        if re.search("^([0-9ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠-])+$", splitted_address_data_dictionaries["invalid"][index]) is not None:
             # 愛知県名古屋市天白区天白町平針黒石２８４５平針住宅14-24
-            if re.search("^[0-9]{2,}", data["invalid"][index]) is not None:
-                match = re.search("^[0-9]{2,}", data["invalid"][index])
+            if re.search("^[0-9]{2,}", splitted_address_data_dictionaries["invalid"][index]) is not None:
+                match = re.search("^[0-9]{2,}", splitted_address_data_dictionaries["invalid"][index])
                 assert match is not None
-                invalid_word = data["invalid"][index]
+                invalid_word = splitted_address_data_dictionaries["invalid"][index]
                 if index is not None:
-                    others_tail[index] = invalid_word[match.end() :] + data["house_number"][index] + others_tail[index]
-                    data["house_number"][index] = invalid_word[0 : match.end()]
-                    data["invalid"][index] = ""
+                    others_tail[index] = (
+                        invalid_word[match.end() :]
+                        + splitted_address_data_dictionaries["house_number"][index]
+                        + others_tail[index]
+                    )
+                    splitted_address_data_dictionaries["house_number"][index] = invalid_word[0 : match.end()]
+                    splitted_address_data_dictionaries["invalid"][index] = ""
 
             MAPPING_ARITHMETIC_NUMBER_TO_JAPANESE_NUMBER: dict = {
                 "1": "一",
@@ -33,7 +37,7 @@ def check(data: dict[str, list[str]], others_tail: list[str]) -> list[str]:
             }
             numbers: list = [str(i) for i in range(1, 10)]
             res: str = ""
-            for char in data["invalid"][index]:
+            for char in splitted_address_data_dictionaries["invalid"][index]:
                 if char in numbers:
                     res = res + MAPPING_ARITHMETIC_NUMBER_TO_JAPANESE_NUMBER[char]
                 else:
@@ -43,15 +47,15 @@ def check(data: dict[str, list[str]], others_tail: list[str]) -> list[str]:
             return ""
 
     caution: list = []
-    for index in range(len(data["invalid"])):
+    for index in range(len(splitted_address_data_dictionaries["invalid"])):
         response: str = check_valid_word_or_not(index)
-        if data["invalid"][index] == "":
+        if splitted_address_data_dictionaries["invalid"][index] == "":
             caution.append("")
         elif response == "":
             # 不正な文字列
             caution.append("ERROR: データは、整形不可能な状態です。自動整形システムは正しく動作しません。この行の全ての結果を確認することを推奨します。  ")
         else:
             caution.append("")
-            data["invalid"][index] = ""
-            data["district"][index] += response
+            splitted_address_data_dictionaries["invalid"][index] = ""
+            splitted_address_data_dictionaries["district"][index] += response
     return caution

--- a/address_separator/utils/extract/detail/check/data_check.py
+++ b/address_separator/utils/extract/detail/check/data_check.py
@@ -4,30 +4,30 @@ import re
 import pandas as pd
 
 
-def data_check(data: dict[str, list[str]]):
+def data_check(splitted_address_data_dictionaries: dict[str, list[str]]):
     """
     総務省のデータから実在する市町村であるかどうか調べる
     """
     Current_Path = os.getcwd()
     PATH = Current_Path + "/data/administrative_district.csv"
     administrative_data_csv: pd.DataFrame = pd.read_csv(PATH)
-    for index in range(len(data["prefecture"])):
-        prefecture: str = data["prefecture"][index]
+    for index in range(len(splitted_address_data_dictionaries["prefecture"])):
+        prefecture: str = splitted_address_data_dictionaries["prefecture"][index]
         if prefecture == "":
             continue
-        if data["city"][index] in list(administrative_data_csv[prefecture]):
+        if splitted_address_data_dictionaries["city"][index] in list(administrative_data_csv[prefecture]):
             pass
-        elif re.search("郡", data["city"][index]):
+        elif re.search("郡", splitted_address_data_dictionaries["city"][index]):
             continue
         else:
-            data["error1"][index] += "ERROR: address1の列の情報が不正です。自動整形過程で何らかの問題が発生しました。  "
+            splitted_address_data_dictionaries["error1"][index] += "ERROR: address1の列の情報が不正です。自動整形過程で何らかの問題が発生しました。  "
     # 政令指定都市に関してはさらに詳しくチェック
     CHECH_PATH = "data/Ordinance_designated_city.csv"
     Ordinance_designated_city_csv: pd.DataFrame = pd.read_csv(CHECH_PATH)
-    for index in range(len(data["city"])):
-        if data["city"][index] in list(Ordinance_designated_city_csv.columns):
-            city_name = data["city"][index]
-            if data["town"][index] in list(Ordinance_designated_city_csv[city_name]):
+    for index in range(len(splitted_address_data_dictionaries["city"])):
+        if splitted_address_data_dictionaries["city"][index] in list(Ordinance_designated_city_csv.columns):
+            city_name = splitted_address_data_dictionaries["city"][index]
+            if splitted_address_data_dictionaries["town"][index] in list(Ordinance_designated_city_csv[city_name]):
                 pass
             else:
-                data["error1"][index] += "ERROR: address2の列の情報が不正です。自動整形過程で何らかの問題が発生しました。  "
+                splitted_address_data_dictionaries["error1"][index] += "ERROR: address2の列の情報が不正です。自動整形過程で何らかの問題が発生しました。  "

--- a/address_separator/utils/extract/detail/check/data_check.py
+++ b/address_separator/utils/extract/detail/check/data_check.py
@@ -4,7 +4,7 @@ import re
 import pandas as pd
 
 
-def data_check(data: dict):
+def data_check(data: dict[str, list[str]]):
     """
     総務省のデータから実在する市町村であるかどうか調べる
     """

--- a/address_separator/utils/extract/detail/check/detail_data_check.py
+++ b/address_separator/utils/extract/detail/check/detail_data_check.py
@@ -1,7 +1,7 @@
 import utils.data_create.shapping
 
 
-def detail_check(data: dict):
+def detail_check(data: dict[str, list[str]]):
     # 町域に関するテスト
     data_set = utils.data_create.shapping.main()
     for index in range(len(data["address1"])):

--- a/address_separator/utils/extract/detail/check/detail_data_check.py
+++ b/address_separator/utils/extract/detail/check/detail_data_check.py
@@ -1,25 +1,29 @@
 import utils.data_create.shapping
 
 
-def detail_check(data: dict[str, list[str]]):
+def detail_check(splitted_address_data_dictionaries: dict[str, list[str]]):
     # 町域に関するテスト
-    data_set = utils.data_create.shapping.main()
-    for index in range(len(data["address1"])):
-        address1_value = data["address1"][index]
+    splitted_address_data_dictionaries_set = utils.data_create.shapping.main()
+    for index in range(len(splitted_address_data_dictionaries["address1"])):
+        address1_value = splitted_address_data_dictionaries["address1"][index]
         if address1_value == "":
-            data["error2"][index] += "ERROR: address1の列の情報がありません。市区町村以降の自動チェック機構はこの行には働きません。  "
+            splitted_address_data_dictionaries["error2"][
+                index
+            ] += "ERROR: address1の列の情報がありません。市区町村以降の自動チェック機構はこの行には働きません。  "
             continue
-        address2_value = data["address2"][index]
+        address2_value = splitted_address_data_dictionaries["address2"][index]
         try:
-            if address2_value in data_set[address1_value]:
+            if address2_value in splitted_address_data_dictionaries_set[address1_value]:
                 pass
             else:
-                data["error1"][index] += "ERROR: address2のデータは、自動チェック機構が参照する日本郵便のデータセットに合致しません。  "
+                splitted_address_data_dictionaries["error1"][
+                    index
+                ] += "ERROR: address2のデータは、自動チェック機構が参照する日本郵便のデータセットに合致しません。  "
         except KeyError:
-            data["error1"][
+            splitted_address_data_dictionaries["error1"][
                 index
             ] += "ERROR: address2のデータは、address1のデータから推測されるデータに一致しません。（自動チェック機構が参照するデータセットに合致しないか、表記が異なります。  "
     # 番地に関するテスト
-    for index in range(len(data["address3"])):
-        if data["address3"][index] == "":
-            data["error2"][index] += "ERROR: address3の列の情報がありません。  "
+    for index in range(len(splitted_address_data_dictionaries["address3"])):
+        if splitted_address_data_dictionaries["address3"][index] == "":
+            splitted_address_data_dictionaries["error2"][index] += "ERROR: address3の列の情報がありません。  "

--- a/address_separator/utils/extract/detail/house_number.py
+++ b/address_separator/utils/extract/detail/house_number.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 

--- a/address_separator/utils/extract/detail/house_number.py
+++ b/address_separator/utils/extract/detail/house_number.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 
 
-def operation(others: list):
+def operation(others: list[str]):
     """1-7-6 のような番地を抽出する。"""
     house_numbers: list = []
     others_head: list = []

--- a/address_separator/utils/extract/detail/manipulate.py
+++ b/address_separator/utils/extract/detail/manipulate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 

--- a/address_separator/utils/extract/detail/manipulate.py
+++ b/address_separator/utils/extract/detail/manipulate.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import re
 
 
-def manipulate(data: dict[str, list[str]], others_tail: list):
+def manipulate(splitted_address_data_dictionaries: dict[str, list[str]], others_tail: list):
     """番地を取り除いた後のデータに関して、処理を行い後の操作で処理を行いやすくする。"""
     manipulated_others_tail: list = []
 
     for id in range(len(others_tail)):
         if re.match("[0-9]+$", others_tail[id]):
-            data["house_number"][id] = data["house_number"][id] + others_tail[id]
+            splitted_address_data_dictionaries["house_number"][id] = (
+                splitted_address_data_dictionaries["house_number"][id] + others_tail[id]
+            )
             manipulated_others_tail.append("")
         else:
             manipulated_others_tail.append(others_tail[id])
@@ -37,7 +39,7 @@ def manipulate(data: dict[str, list[str]], others_tail: list):
         else:
             pass
 
-    data["special_characters"] = special_characters
+    splitted_address_data_dictionaries["special_characters"] = special_characters
 
     def extract_number_from_others_tail(string: str):
         if string == "":
@@ -51,7 +53,9 @@ def manipulate(data: dict[str, list[str]], others_tail: list):
             end: int = extract_number_from_others_tail(manipulated_others_tail[i]).end()
             if start != 0:
                 print("something wrong")  # for debug
-            data["house_number"][i] = data["house_number"][i] + manipulated_others_tail[i][start:end]
+            splitted_address_data_dictionaries["house_number"][i] = (
+                splitted_address_data_dictionaries["house_number"][i] + manipulated_others_tail[i][start:end]
+            )
             manipulated_others_tail[i] = manipulated_others_tail[i][end:]
         else:
             pass

--- a/address_separator/utils/extract/detail/manipulate.py
+++ b/address_separator/utils/extract/detail/manipulate.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 
 
-def manipulate(data: dict, others_tail: list):
+def manipulate(data: dict[str, list[str]], others_tail: list):
     """番地を取り除いた後のデータに関して、処理を行い後の操作で処理を行いやすくする。"""
     manipulated_others_tail: list = []
 

--- a/address_separator/utils/extract/detail/shaping.py
+++ b/address_separator/utils/extract/detail/shaping.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 

--- a/address_separator/utils/extract/detail/shaping.py
+++ b/address_separator/utils/extract/detail/shaping.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 
 
-def shaping(data: dict):
+def shaping(data: dict[str, list[str]]):
     """分割等が終了したデータに対して、これらを出力用に整形する。
     特殊な名前の市町村等のデータについても、ここで整形作業を行う.
     """

--- a/address_separator/utils/extract/detail/shaping.py
+++ b/address_separator/utils/extract/detail/shaping.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 import re
 
 
-def shaping(data: dict[str, list[str]]):
+def shaping(splitted_address_data_dictionaries: dict[str, list[str]]):
     """分割等が終了したデータに対して、これらを出力用に整形する。
     特殊な名前の市町村等のデータについても、ここで整形作業を行う.
     """
     # データの最終整形 都市名のうち半角数字のものは漢字に直す
-    for index in range(len(data["city"])):
-        if data["city"][index] == "":
+    for index in range(len(splitted_address_data_dictionaries["city"])):
+        if splitted_address_data_dictionaries["city"][index] == "":
             continue
-        if re.search("[1-9]", data["city"][index]) is not None:
+        if re.search("[1-9]", splitted_address_data_dictionaries["city"][index]) is not None:
             shaped: str = ""
             mapping_dictionary: dict = {
                 "1": "一",
@@ -25,19 +25,19 @@ def shaping(data: dict[str, list[str]]):
                 "9": "九",
             }
             numbers: list = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
-            for char in data["city"][index]:
+            for char in splitted_address_data_dictionaries["city"][index]:
                 if char in numbers:
                     shaped += mapping_dictionary[char]
                 else:
                     shaped += char
-            data["city"][index] = shaped
+            splitted_address_data_dictionaries["city"][index] = shaped
         else:
             pass
     # 上記と同様のことをtownでもやる。ただし漢字+ひらがな+算用数字のときのみ
-    for index in range(len(data["town"])):
-        if data["town"][index] == "":
+    for index in range(len(splitted_address_data_dictionaries["town"])):
+        if splitted_address_data_dictionaries["town"][index] == "":
             continue
-        if re.search("[1-9]", data["town"][index]) is not None:
+        if re.search("[1-9]", splitted_address_data_dictionaries["town"][index]) is not None:
             shaped: str = ""
             mapping_dictionary: dict = {
                 "1": "一",
@@ -51,7 +51,7 @@ def shaping(data: dict[str, list[str]]):
                 "9": "九",
             }
             numbers: list = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
-            for char in data["town"][index]:
+            for char in splitted_address_data_dictionaries["town"][index]:
                 if char in numbers:
                     shaped += mapping_dictionary[char]
                 else:
@@ -61,202 +61,271 @@ def shaping(data: dict[str, list[str]]):
                 start: int = re.search("[一-九]-町", shaped).start()
                 shaped = shaped[: start + 1] + "番" + shaped[start + 2 :]
 
-            data["town"][index] = shaped
+            splitted_address_data_dictionaries["town"][index] = shaped
         else:
             pass
     # city の先頭または末尾に-があったら除去
-    for index in range(len(data["city"])):
-        if data["city"][index] == "":
+    for index in range(len(splitted_address_data_dictionaries["city"])):
+        if splitted_address_data_dictionaries["city"][index] == "":
             continue
-        if data["city"][index][0] == "-":
-            data["city"][index] = data["city"][index][1:]
-        if len(data["city"][index]) < 1:
+        if splitted_address_data_dictionaries["city"][index][0] == "-":
+            splitted_address_data_dictionaries["city"][index] = splitted_address_data_dictionaries["city"][index][1:]
+        if len(splitted_address_data_dictionaries["city"][index]) < 1:
             continue
-        if data["city"][index][-1] == "-":
-            data["city"][index] = data["city"][index][:-1]
+        if splitted_address_data_dictionaries["city"][index][-1] == "-":
+            splitted_address_data_dictionaries["city"][index] = splitted_address_data_dictionaries["city"][index][:-1]
     # town の先頭または末尾に-があったら除去
-    for index in range(len(data["town"])):
-        if data["town"][index] == "":
+    for index in range(len(splitted_address_data_dictionaries["town"])):
+        if splitted_address_data_dictionaries["town"][index] == "":
             continue
-        if data["town"][index][0] == "-":
-            data["town"][index] = data["town"][index][1:]
-        if len(data["town"][index]) < 1:
+        if splitted_address_data_dictionaries["town"][index][0] == "-":
+            splitted_address_data_dictionaries["town"][index] = splitted_address_data_dictionaries["town"][index][1:]
+        if len(splitted_address_data_dictionaries["town"][index]) < 1:
             continue
-        if data["town"][index][-1] == "-":
-            data["town"][index] = data["town"][index][:-1]
+        if splitted_address_data_dictionaries["town"][index][-1] == "-":
+            splitted_address_data_dictionaries["town"][index] = splitted_address_data_dictionaries["town"][index][:-1]
     # district の先頭または末尾に-があったら除去
-    for index in range(len(data["district"])):
-        if data["district"][index] == "":
+    for index in range(len(splitted_address_data_dictionaries["district"])):
+        if splitted_address_data_dictionaries["district"][index] == "":
             continue
-        if data["district"][index][0] == "-":
-            data["district"][index] = data["district"][index][1:]
-        if len(data["district"][index]) < 1:
+        if splitted_address_data_dictionaries["district"][index][0] == "-":
+            splitted_address_data_dictionaries["district"][index] = splitted_address_data_dictionaries["district"][
+                index
+            ][1:]
+        if len(splitted_address_data_dictionaries["district"][index]) < 1:
             continue
-        if data["district"][index][-1] == "-":
-            data["district"][index] = data["district"][index][:-1]
+        if splitted_address_data_dictionaries["district"][index][-1] == "-":
+            splitted_address_data_dictionaries["district"][index] = splitted_address_data_dictionaries["district"][
+                index
+            ][:-1]
     # 東京都 町田など、固有名詞に 市、町、区、町、村があるもの
     # 町田市
-    for index in range(len(data["district"])):
-        if data["district"][index] == "":
+    for index in range(len(splitted_address_data_dictionaries["district"])):
+        if splitted_address_data_dictionaries["district"][index] == "":
             continue
-        if data["district"][index] == "田":
-            if data["town"][index] == "":
+        if splitted_address_data_dictionaries["district"][index] == "田":
+            if splitted_address_data_dictionaries["town"][index] == "":
                 continue
-            if data["town"][index][-1] == "町":
-                data["town"][index] += "田"
-                data["district"][index] = ""
+            if splitted_address_data_dictionaries["town"][index][-1] == "町":
+                splitted_address_data_dictionaries["town"][index] += "田"
+                splitted_address_data_dictionaries["district"][index] = ""
             else:
                 pass
         else:
             pass
     # 市川市
-    for index in range(len(data["city"])):
-        if data["city"][index] == "市" and re.search("^川市", data["district"][index]):
-            start: int = re.search("^川市", data["district"][index]).start()
-            end: int = re.search("^川市", data["district"][index]).end()
+    for index in range(len(splitted_address_data_dictionaries["city"])):
+        if splitted_address_data_dictionaries["city"][index] == "市" and re.search(
+            "^川市", splitted_address_data_dictionaries["district"][index]
+        ):
+            start: int = re.search("^川市", splitted_address_data_dictionaries["district"][index]).start()
+            end: int = re.search("^川市", splitted_address_data_dictionaries["district"][index]).end()
             if start != 0:
                 print("something wrong")  # for debug
-            data["city"][index] = "市川市"
-            data["district"][index] = data["district"][index][end:]
+            splitted_address_data_dictionaries["city"][index] = "市川市"
+            splitted_address_data_dictionaries["district"][index] = splitted_address_data_dictionaries["district"][
+                index
+            ][end:]
 
-        elif data["district"][index] == "":
+        elif splitted_address_data_dictionaries["district"][index] == "":
             # どこに残骸があるか不明なので
-            if data["city"][index] == "市" and re.search("^川市", data["town"][index]):
-                start: int = re.search("^川市", data["town"][index]).start()
-                end: int = re.search("^川市", data["town"][index]).end()
+            if splitted_address_data_dictionaries["city"][index] == "市" and re.search(
+                "^川市", splitted_address_data_dictionaries["town"][index]
+            ):
+                start: int = re.search("^川市", splitted_address_data_dictionaries["town"][index]).start()
+                end: int = re.search("^川市", splitted_address_data_dictionaries["town"][index]).end()
                 if start != 0:
                     print("something wrong")  # for debug
-                data["city"][index] = "市川市"
-                data["town"][index] = data["town"][index][end:]
+                splitted_address_data_dictionaries["city"][index] = "市川市"
+                splitted_address_data_dictionaries["town"][index] = splitted_address_data_dictionaries["town"][index][
+                    end:
+                ]
     # 市原市
-    for index in range(len(data["city"])):
-        if data["city"][index] == "市" and re.search("^原市", data["district"][index]):
-            start: int = re.search("^原市", data["district"][index]).start()
-            end: int = re.search("^原市", data["district"][index]).end()
+    for index in range(len(splitted_address_data_dictionaries["city"])):
+        if splitted_address_data_dictionaries["city"][index] == "市" and re.search(
+            "^原市", splitted_address_data_dictionaries["district"][index]
+        ):
+            start: int = re.search("^原市", splitted_address_data_dictionaries["district"][index]).start()
+            end: int = re.search("^原市", splitted_address_data_dictionaries["district"][index]).end()
             if start != 0:
                 print("something wrong")  # for debug
-            data["city"][index] = "市原市"
-            data["district"][index] = data["district"][index][end:]
+            splitted_address_data_dictionaries["city"][index] = "市原市"
+            splitted_address_data_dictionaries["district"][index] = splitted_address_data_dictionaries["district"][
+                index
+            ][end:]
 
-        elif data["district"][index] == "":
+        elif splitted_address_data_dictionaries["district"][index] == "":
             # どこに残骸があるか不明なので
-            if data["city"][index] == "市" and re.search("^原市", data["town"][index]):
-                start: int = re.search("^原市", data["town"][index]).start()
-                end: int = re.search("^原市", data["town"][index]).end()
+            if splitted_address_data_dictionaries["city"][index] == "市" and re.search(
+                "^原市", splitted_address_data_dictionaries["town"][index]
+            ):
+                start: int = re.search("^原市", splitted_address_data_dictionaries["town"][index]).start()
+                end: int = re.search("^原市", splitted_address_data_dictionaries["town"][index]).end()
                 if start != 0:
                     print("something wrong")  # for debug
-                data["city"][index] = "市原市"
-                data["town"][index] = data["town"][index][end:]
+                splitted_address_data_dictionaries["city"][index] = "市原市"
+                splitted_address_data_dictionaries["town"][index] = splitted_address_data_dictionaries["town"][index][
+                    end:
+                ]
     # 野々市市
-    for index in range(len(data["city"])):
-        if data["city"][index] == "野々市" and re.search("^市", data["district"][index]):
-            start: int = re.search("^市", data["district"][index]).start()
-            end: int = re.search("^市", data["district"][index]).end()
+    for index in range(len(splitted_address_data_dictionaries["city"])):
+        if splitted_address_data_dictionaries["city"][index] == "野々市" and re.search(
+            "^市", splitted_address_data_dictionaries["district"][index]
+        ):
+            start: int = re.search("^市", splitted_address_data_dictionaries["district"][index]).start()
+            end: int = re.search("^市", splitted_address_data_dictionaries["district"][index]).end()
             if start != 0:
                 print("something wrong")  # for debug
-            data["city"][index] = "野々市市"
-            data["district"][index] = data["district"][index][end:]
+            splitted_address_data_dictionaries["city"][index] = "野々市市"
+            splitted_address_data_dictionaries["district"][index] = splitted_address_data_dictionaries["district"][
+                index
+            ][end:]
 
-        elif data["district"][index] == "":
+        elif splitted_address_data_dictionaries["district"][index] == "":
             # どこに残骸があるか不明なので
-            if data["city"][index] == "野々市" and re.search("^市", data["town"][index]):
-                start: int = re.search("^市", data["town"][index]).start()
-                end: int = re.search("^市", data["town"][index]).end()
+            if splitted_address_data_dictionaries["city"][index] == "野々市" and re.search(
+                "^市", splitted_address_data_dictionaries["town"][index]
+            ):
+                start: int = re.search("^市", splitted_address_data_dictionaries["town"][index]).start()
+                end: int = re.search("^市", splitted_address_data_dictionaries["town"][index]).end()
                 if start != 0:
                     print("something wrong")  # for debug
-                data["city"][index] = "野々市市"
-                data["town"][index] = data["town"][index][end:]
+                splitted_address_data_dictionaries["city"][index] = "野々市市"
+                splitted_address_data_dictionaries["town"][index] = splitted_address_data_dictionaries["town"][index][
+                    end:
+                ]
     # 四日市市
-    for index in range(len(data["city"])):
-        if data["city"][index] == "四日市" and re.search("^市", data["district"][index]):
-            start: int = re.search("^市", data["district"][index]).start()
-            end: int = re.search("^市", data["district"][index]).end()
+    for index in range(len(splitted_address_data_dictionaries["city"])):
+        if splitted_address_data_dictionaries["city"][index] == "四日市" and re.search(
+            "^市", splitted_address_data_dictionaries["district"][index]
+        ):
+            start: int = re.search("^市", splitted_address_data_dictionaries["district"][index]).start()
+            end: int = re.search("^市", splitted_address_data_dictionaries["district"][index]).end()
             if start != 0:
                 print("something wrong")  # for debug
-            data["city"][index] = "四日市市"
-            data["district"][index] = data["district"][index][end:]
+            splitted_address_data_dictionaries["city"][index] = "四日市市"
+            splitted_address_data_dictionaries["district"][index] = splitted_address_data_dictionaries["district"][
+                index
+            ][end:]
 
-        elif data["district"][index] == "":
+        elif splitted_address_data_dictionaries["district"][index] == "":
             # どこに残骸があるか不明なので
-            if data["city"][index] == "四日市" and re.search("^市", data["town"][index]):
-                start: int = re.search("^市", data["town"][index]).start()
-                end: int = re.search("^市", data["town"][index]).end()
+            if splitted_address_data_dictionaries["city"][index] == "四日市" and re.search(
+                "^市", splitted_address_data_dictionaries["town"][index]
+            ):
+                start: int = re.search("^市", splitted_address_data_dictionaries["town"][index]).start()
+                end: int = re.search("^市", splitted_address_data_dictionaries["town"][index]).end()
                 if start != 0:
                     print("something wrong")  # for debug
-                data["city"][index] = "四日市市"
-                data["town"][index] = data["town"][index][end:]
+                splitted_address_data_dictionaries["city"][index] = "四日市市"
+                splitted_address_data_dictionaries["town"][index] = splitted_address_data_dictionaries["town"][index][
+                    end:
+                ]
     # 廿日市市
-    for index in range(len(data["city"])):
-        if data["city"][index] == "廿日市" and re.search("^市", data["district"][index]):
-            start: int = re.search("^市", data["district"][index]).start()
-            end: int = re.search("^市", data["district"][index]).end()
+    for index in range(len(splitted_address_data_dictionaries["city"])):
+        if splitted_address_data_dictionaries["city"][index] == "廿日市" and re.search(
+            "^市", splitted_address_data_dictionaries["district"][index]
+        ):
+            start: int = re.search("^市", splitted_address_data_dictionaries["district"][index]).start()
+            end: int = re.search("^市", splitted_address_data_dictionaries["district"][index]).end()
             if start != 0:
                 print("something wrong")  # for debug
-            data["city"][index] = "廿日市市"
-            data["district"][index] = data["district"][index][end:]
+            splitted_address_data_dictionaries["city"][index] = "廿日市市"
+            splitted_address_data_dictionaries["district"][index] = splitted_address_data_dictionaries["district"][
+                index
+            ][end:]
 
-        elif data["district"][index] == "":
+        elif splitted_address_data_dictionaries["district"][index] == "":
             # どこに残骸があるか不明なので
-            if data["city"][index] == "廿日市" and re.search("^市", data["town"][index]):
-                start: int = re.search("^市", data["town"][index]).start()
-                end: int = re.search("^市", data["town"][index]).end()
+            if splitted_address_data_dictionaries["city"][index] == "廿日市" and re.search(
+                "^市", splitted_address_data_dictionaries["town"][index]
+            ):
+                start: int = re.search("^市", splitted_address_data_dictionaries["town"][index]).start()
+                end: int = re.search("^市", splitted_address_data_dictionaries["town"][index]).end()
                 if start != 0:
                     print("something wrong")  # for debug
-                data["city"][index] = "廿日市市"
-                data["town"][index] = data["town"][index][end:]
+                splitted_address_data_dictionaries["city"][index] = "廿日市市"
+                splitted_address_data_dictionaries["town"][index] = splitted_address_data_dictionaries["town"][index][
+                    end:
+                ]
     # 余市軍
-    for index in range(len(data["city"])):
-        if data["city"][index] == "余市" and re.search("^郡", data["district"][index]):
-            start: int = re.search("^郡", data["district"][index]).start()
-            end: int = re.search("^郡", data["district"][index]).end()
+    for index in range(len(splitted_address_data_dictionaries["city"])):
+        if splitted_address_data_dictionaries["city"][index] == "余市" and re.search(
+            "^郡", splitted_address_data_dictionaries["district"][index]
+        ):
+            start: int = re.search("^郡", splitted_address_data_dictionaries["district"][index]).start()
+            end: int = re.search("^郡", splitted_address_data_dictionaries["district"][index]).end()
             if start != 0:
                 print("something wrong")  # for debug
-            data["city"][index] = "余市郡"
-            data["district"][index] = data["district"][index][end:]
+            splitted_address_data_dictionaries["city"][index] = "余市郡"
+            splitted_address_data_dictionaries["district"][index] = splitted_address_data_dictionaries["district"][
+                index
+            ][end:]
 
-        elif data["district"][index] == "":
+        elif splitted_address_data_dictionaries["district"][index] == "":
             # どこに残骸があるか不明なので
-            if data["city"][index] == "余市" and re.search("^郡", data["town"][index]):
-                start: int = re.search("^郡", data["town"][index]).start()
-                end: int = re.search("^郡", data["town"][index]).end()
+            if splitted_address_data_dictionaries["city"][index] == "余市" and re.search(
+                "^郡", splitted_address_data_dictionaries["town"][index]
+            ):
+                start: int = re.search("^郡", splitted_address_data_dictionaries["town"][index]).start()
+                end: int = re.search("^郡", splitted_address_data_dictionaries["town"][index]).end()
                 if start != 0:
                     print("something wrong")  # for debug
-                data["city"][index] = "余市郡"
-                data["town"][index] = data["town"][index][end:]
-        elif re.search("^[- 0-9 町 市]", data["district"][index]) is None:
+                splitted_address_data_dictionaries["city"][index] = "余市郡"
+                splitted_address_data_dictionaries["town"][index] = splitted_address_data_dictionaries["town"][index][
+                    end:
+                ]
+        elif re.search("^[- 0-9 町 市]", splitted_address_data_dictionaries["district"][index]) is None:
             # どこに残骸があるか不明なので
-            if data["city"][index] == "余市" and re.search("^郡", data["town"][index]):
-                start: int = re.search("^郡", data["town"][index]).start()
-                end: int = re.search("^郡", data["town"][index]).end()
+            if splitted_address_data_dictionaries["city"][index] == "余市" and re.search(
+                "^郡", splitted_address_data_dictionaries["town"][index]
+            ):
+                start: int = re.search("^郡", splitted_address_data_dictionaries["town"][index]).start()
+                end: int = re.search("^郡", splitted_address_data_dictionaries["town"][index]).end()
                 if start != 0:
                     print("something wrong")  # for debug
-                data["city"][index] = "余市郡"
-                data["town"][index] = data["town"][index][end:]
-                if data["town"][index] == "" and re.search("[町]$", data["district"][index]):
+                splitted_address_data_dictionaries["city"][index] = "余市郡"
+                splitted_address_data_dictionaries["town"][index] = splitted_address_data_dictionaries["town"][index][
+                    end:
+                ]
+                if splitted_address_data_dictionaries["town"][index] == "" and re.search(
+                    "[町]$", splitted_address_data_dictionaries["district"][index]
+                ):
                     # 文字列の分解位置をずらす
-                    data["town"][index] = data["district"][index]
-                    data["district"][index] = ""
+                    splitted_address_data_dictionaries["town"][index] = splitted_address_data_dictionaries["district"][
+                        index
+                    ]
+                    splitted_address_data_dictionaries["district"][index] = ""
     # 市貝町
-    for index in range(len(data["city"])):
-        if re.search("-市$", data["city"][index]):
-            start: int = re.search("-市$", data["city"][index]).start()
-            end: int = re.search("-市$", data["city"][index]).end()
-            if data["town"][index] == "貝町":
-                data["town"][index] = "市貝町"
-                data["city"][index] = data["city"][index][:start]
+    for index in range(len(splitted_address_data_dictionaries["city"])):
+        if re.search("-市$", splitted_address_data_dictionaries["city"][index]):
+            start: int = re.search("-市$", splitted_address_data_dictionaries["city"][index]).start()
+            end: int = re.search("-市$", splitted_address_data_dictionaries["city"][index]).end()
+            if splitted_address_data_dictionaries["town"][index] == "貝町":
+                splitted_address_data_dictionaries["town"][index] = "市貝町"
+                splitted_address_data_dictionaries["city"][index] = splitted_address_data_dictionaries["city"][index][
+                    :start
+                ]
     # 市川三郷町
-    for index in range(len(data["city"])):
-        if re.search("-市$", data["city"][index]):
-            start: int = re.search("-市$", data["city"][index]).start()
-            end: int = re.search("-市$", data["city"][index]).end()
-            if data["town"][index] == "川3郷町":
-                data["town"][index] = "市川三郷町"
-                data["city"][index] = data["city"][index][:start]
-            elif data["town"][index] == "川三郷町":
-                data["town"][index] = "市川三郷町"
-                data["city"][index] = data["city"][index][:start]
+    for index in range(len(splitted_address_data_dictionaries["city"])):
+        if re.search("-市$", splitted_address_data_dictionaries["city"][index]):
+            start: int = re.search("-市$", splitted_address_data_dictionaries["city"][index]).start()
+            end: int = re.search("-市$", splitted_address_data_dictionaries["city"][index]).end()
+            if splitted_address_data_dictionaries["town"][index] == "川3郷町":
+                splitted_address_data_dictionaries["town"][index] = "市川三郷町"
+                splitted_address_data_dictionaries["city"][index] = splitted_address_data_dictionaries["city"][index][
+                    :start
+                ]
+            elif splitted_address_data_dictionaries["town"][index] == "川三郷町":
+                splitted_address_data_dictionaries["town"][index] = "市川三郷町"
+                splitted_address_data_dictionaries["city"][index] = splitted_address_data_dictionaries["city"][index][
+                    :start
+                ]
     # 市ケ坂町
-    for index in range(len(data["city"])):
-        if data["city"][index] == "市" and data["town"][index] == "ケ坂町":
-            data["city"][index] = "市ケ坂町"
-            data["town"][index] = ""
+    for index in range(len(splitted_address_data_dictionaries["city"])):
+        if (
+            splitted_address_data_dictionaries["city"][index] == "市"
+            and splitted_address_data_dictionaries["town"][index] == "ケ坂町"
+        ):
+            splitted_address_data_dictionaries["city"][index] = "市ケ坂町"
+            splitted_address_data_dictionaries["town"][index] = ""

--- a/address_separator/utils/extract/detail/shaping_building_info.py
+++ b/address_separator/utils/extract/detail/shaping_building_info.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 

--- a/address_separator/utils/extract/detail/shaping_building_info.py
+++ b/address_separator/utils/extract/detail/shaping_building_info.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 
 
-def shaping_and_extracting_building_info(data: dict, manipulated_others_tail: list):
+def shaping_and_extracting_building_info(data: dict[str, list[str]], manipulated_others_tail: list):
     """ビル名、建物名など、building_infoに含まれる。または、building_detail_infoに含まれるデータを抽出、整形する"""
 
     def find_kai(string: str):

--- a/address_separator/utils/extract/detail/shaping_building_info.py
+++ b/address_separator/utils/extract/detail/shaping_building_info.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import re
 
 
-def shaping_and_extracting_building_info(data: dict[str, list[str]], manipulated_others_tail: list):
+def shaping_and_extracting_building_info(
+    splitted_address_data_dictionaries: dict[str, list[str]], manipulated_others_tail: list
+):
     """ビル名、建物名など、building_infoに含まれる。または、building_detail_infoに含まれるデータを抽出、整形する"""
 
     def find_kai(string: str):
@@ -15,19 +17,23 @@ def shaping_and_extracting_building_info(data: dict[str, list[str]], manipulated
 
     def cutting_number_from_last2(index: int):
         """上記の関数と同時に使用する。8階のように、建物の階数情報のみを抽出する"""
-        if re.search("-([0-9]+)$", data["house_number"][index]) is None:
+        if re.search("-([0-9]+)$", splitted_address_data_dictionaries["house_number"][index]) is None:
             print(index)  # for debug
-            print(re.search("-([0-9]+)$", data["house_number"][index]))
-            print(data["house_number"][index])
+            print(re.search("-([0-9]+)$", splitted_address_data_dictionaries["house_number"][index]))
+            print(splitted_address_data_dictionaries["house_number"][index])
             print("something wrong1")  # for debug
         else:
-            start: int = re.search("-([0-9]+)$", data["house_number"][index]).start()
-            end: int = re.search("-([0-9]+)$", data["house_number"][index]).end()
-            if end != len(data["house_number"][index]):
+            start: int = re.search("-([0-9]+)$", splitted_address_data_dictionaries["house_number"][index]).start()
+            end: int = re.search("-([0-9]+)$", splitted_address_data_dictionaries["house_number"][index]).end()
+            if end != len(splitted_address_data_dictionaries["house_number"][index]):
                 print("somethin wrong2")  # for debug
             # start+1 にしているのは-{数字}階となっているので - を除いている
-            data["building_detail_info"][index] = data["house_number"][index][start + 1 : end] + "階"
-            data["house_number"][index] = data["house_number"][index][:start]
+            splitted_address_data_dictionaries["building_detail_info"][index] = (
+                splitted_address_data_dictionaries["house_number"][index][start + 1 : end] + "階"
+            )
+            splitted_address_data_dictionaries["house_number"][index] = splitted_address_data_dictionaries[
+                "house_number"
+            ][index][:start]
 
     for i in range(len(manipulated_others_tail)):
         if find_kai(manipulated_others_tail[i]):
@@ -47,19 +53,23 @@ def shaping_and_extracting_building_info(data: dict[str, list[str]], manipulated
 
     def cutting_number_from_last3(index: int):
         """上記の関数と同時に使用する。8号のように、建物の階数情報のみを抽出する"""
-        if re.search("-([0-9]+)$", data["house_number"][index]) is None:
+        if re.search("-([0-9]+)$", splitted_address_data_dictionaries["house_number"][index]) is None:
             print(index)
-            print(re.search("-([0-9]+)$", data["house_number"][index]))
-            print(data["house_number"][index])
+            print(re.search("-([0-9]+)$", splitted_address_data_dictionaries["house_number"][index]))
+            print(splitted_address_data_dictionaries["house_number"][index])
             print("something wrong1")  # for debug
         else:
-            start: int = re.search("-([0-9]+)$", data["house_number"][index]).start()
-            end: int = re.search("-([0-9]+)$", data["house_number"][index]).end()
-            if end != len(data["house_number"][index]):
+            start: int = re.search("-([0-9]+)$", splitted_address_data_dictionaries["house_number"][index]).start()
+            end: int = re.search("-([0-9]+)$", splitted_address_data_dictionaries["house_number"][index]).end()
+            if end != len(splitted_address_data_dictionaries["house_number"][index]):
                 print("somethin wrong2")  # for debug
             # start+1 にしているのは-{数字}階となっているので - を除いている
-            data["building_detail_info"][index] = data["house_number"][index][start + 1 : end] + "号"
-            data["house_number"][index] = data["house_number"][index][:start]
+            splitted_address_data_dictionaries["building_detail_info"][index] = (
+                splitted_address_data_dictionaries["house_number"][index][start + 1 : end] + "号"
+            )
+            splitted_address_data_dictionaries["house_number"][index] = splitted_address_data_dictionaries[
+                "house_number"
+            ][index][:start]
 
     for i in range(len(manipulated_others_tail)):
         if find_gou(manipulated_others_tail[i]):
@@ -81,7 +91,9 @@ def shaping_and_extracting_building_info(data: dict[str, list[str]], manipulated
             building_info = manipulated_others_tail[index][start:end]
             manipulated_others_tail[index] = manipulated_others_tail[index][:start]
             # 順番に注意
-            data["building_detail_info"][index] = building_info + data["building_detail_info"][index]
+            splitted_address_data_dictionaries["building_detail_info"][index] = (
+                building_info + splitted_address_data_dictionaries["building_detail_info"][index]
+            )
         else:
             pass
 
@@ -94,7 +106,9 @@ def shaping_and_extracting_building_info(data: dict[str, list[str]], manipulated
             building_info = manipulated_others_tail[index][start:end]
             manipulated_others_tail[index] = manipulated_others_tail[index][:start]
             # 順番に注意
-            data["building_detail_info"][index] = building_info + data["building_detail_info"][index]
+            splitted_address_data_dictionaries["building_detail_info"][index] = (
+                building_info + splitted_address_data_dictionaries["building_detail_info"][index]
+            )
         else:
             pass
 
@@ -107,7 +121,9 @@ def shaping_and_extracting_building_info(data: dict[str, list[str]], manipulated
             building_info = manipulated_others_tail[index][start:end]
             manipulated_others_tail[index] = manipulated_others_tail[index][:start]
             # 順番に注意
-            data["building_detail_info"][index] = building_info + data["building_detail_info"][index]
+            splitted_address_data_dictionaries["building_detail_info"][index] = (
+                building_info + splitted_address_data_dictionaries["building_detail_info"][index]
+            )
         else:
             pass
 
@@ -120,7 +136,9 @@ def shaping_and_extracting_building_info(data: dict[str, list[str]], manipulated
             building_info = manipulated_others_tail[index][start:end]
             manipulated_others_tail[index] = manipulated_others_tail[index][:start]
             # 順番に注意
-            data["building_detail_info"][index] = building_info + data["building_detail_info"][index]
+            splitted_address_data_dictionaries["building_detail_info"][index] = (
+                building_info + splitted_address_data_dictionaries["building_detail_info"][index]
+            )
         else:
             pass
 
@@ -133,7 +151,9 @@ def shaping_and_extracting_building_info(data: dict[str, list[str]], manipulated
             building_info = manipulated_others_tail[index][start:end]
             manipulated_others_tail[index] = manipulated_others_tail[index][:start]
             # 順番に注意
-            data["building_detail_info"][index] = building_info + data["building_detail_info"][index]
+            splitted_address_data_dictionaries["building_detail_info"][index] = (
+                building_info + splitted_address_data_dictionaries["building_detail_info"][index]
+            )
         else:
             pass
 
@@ -146,7 +166,9 @@ def shaping_and_extracting_building_info(data: dict[str, list[str]], manipulated
             building_info = manipulated_others_tail[index][start:end]
             manipulated_others_tail[index] = manipulated_others_tail[index][:start]
             # 順番に注意
-            data["building_detail_info"][index] = building_info + data["building_detail_info"][index]
+            splitted_address_data_dictionaries["building_detail_info"][index] = (
+                building_info + splitted_address_data_dictionaries["building_detail_info"][index]
+            )
         else:
             pass
 
@@ -159,7 +181,9 @@ def shaping_and_extracting_building_info(data: dict[str, list[str]], manipulated
             building_info = manipulated_others_tail[index][start:end]
             manipulated_others_tail[index] = manipulated_others_tail[index][:start]
             # 順番に注意
-            data["building_detail_info"][index] = building_info + data["building_detail_info"][index]
+            splitted_address_data_dictionaries["building_detail_info"][index] = (
+                building_info + splitted_address_data_dictionaries["building_detail_info"][index]
+            )
         else:
             pass
 
@@ -172,7 +196,9 @@ def shaping_and_extracting_building_info(data: dict[str, list[str]], manipulated
             building_info = manipulated_others_tail[index][start:end]
             manipulated_others_tail[index] = manipulated_others_tail[index][:start]
             # 順番に注意
-            data["building_detail_info"][index] = building_info + data["building_detail_info"][index]
+            splitted_address_data_dictionaries["building_detail_info"][index] = (
+                building_info + splitted_address_data_dictionaries["building_detail_info"][index]
+            )
         else:
             pass
 

--- a/address_separator/utils/extract/district.py
+++ b/address_separator/utils/extract/district.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from utils.split.pullOutDistrictField import pull_out_district_field
 
 

--- a/address_separator/utils/extract/prefecture.py
+++ b/address_separator/utils/extract/prefecture.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def extract_prefecture(address_data: str) -> tuple[str, str]:
     """
     extract prefecture: 都道府県を抽出する

--- a/address_separator/utils/extract/town.py
+++ b/address_separator/utils/extract/town.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def extract_town(non_city_address_data: list[str]) -> tuple[list[str], list[str]]:
     """
     市町村よりさらに細かな地区行政区分を文字列から取得する

--- a/address_separator/utils/modify/handle_miscellaneous_bug.py
+++ b/address_separator/utils/modify/handle_miscellaneous_bug.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 

--- a/address_separator/utils/modify/modify_building_data_field_after_split.py
+++ b/address_separator/utils/modify/modify_building_data_field_after_split.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 

--- a/address_separator/utils/modify/modify_exception_address_expression.py
+++ b/address_separator/utils/modify/modify_exception_address_expression.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def modify_exception_case_address2(
     splitted_address_data_dictionaries: dict[str, list[str]], target_index: int
 ) -> None:

--- a/address_separator/utils/modify/modify_special_place_name_after_split.py
+++ b/address_separator/utils/modify/modify_special_place_name_after_split.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 

--- a/address_separator/utils/modify/operation.py
+++ b/address_separator/utils/modify/operation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from utils.modify.handle_miscellaneous_bug import handle_miscellaneous_bugs
 from utils.modify.modify_building_data_field_after_split import modify_building_dat_field
 from utils.modify.modify_special_place_name_after_split import modify_special_place_name

--- a/address_separator/utils/modify/resplit_by_every_field_after_split.py
+++ b/address_separator/utils/modify/resplit_by_every_field_after_split.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 from utils.modify.modify_exception_address_expression import modify_exception_case_address2

--- a/address_separator/utils/preprocess/operation.py
+++ b/address_separator/utils/preprocess/operation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pandas as pd
 import utils.preprocess.post.fix_special_name_address as post
 import utils.preprocess.pre.process_japanese_address_expression as pre

--- a/address_separator/utils/preprocess/post/fix_special_name_address.py
+++ b/address_separator/utils/preprocess/post/fix_special_name_address.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 

--- a/address_separator/utils/preprocess/post/fix_special_name_address.py
+++ b/address_separator/utils/preprocess/post/fix_special_name_address.py
@@ -153,6 +153,17 @@ def reshape_exceptional_address_address_data_array(address_data_array: list[str]
         address_data_array[index] = re.sub("8條", "八條", address_data_array[index])
         # 二番町
         address_data_array[index] = re.sub("2番町", "二番町", address_data_array[index])
+        # 八幡
+        address_data_array[index] = re.sub("8幡", "八幡", address_data_array[index])
+        # 八山
+        address_data_array[index] = re.sub("8山", "八山", address_data_array[index])
+        # 八事
+        address_data_array[index] = re.sub("8事", "八事", address_data_array[index])
+        # 一つ山
+        address_data_array[index] = re.sub("1つ山", "一つ山", address_data_array[index])
+        # 三旺
+        address_data_array[index] = re.sub("3旺", "三旺", address_data_array[index])
+
         #
         address_data_array[index] = re.sub("", "", address_data_array[index])
 

--- a/address_separator/utils/preprocess/pre/fix_special_building_name.py
+++ b/address_separator/utils/preprocess/pre/fix_special_building_name.py
@@ -21,7 +21,6 @@ def escape_special_building_name(address_data: str, special_building_name: str) 
 
 
 def rename_special_building_name(address_data: str, special_building_name: str) -> str:
-    # 丁目ビル,丁目ビルディング
     if "escape_special_building_name" in address_data:
         address_data = re.sub("escape_special_building_name", special_building_name, address_data)
 

--- a/address_separator/utils/preprocess/pre/fix_special_building_name.py
+++ b/address_separator/utils/preprocess/pre/fix_special_building_name.py
@@ -1,0 +1,28 @@
+import re
+
+
+def escape_special_building_name(address_data: str, special_building_name: str) -> str:
+    # 丁目ビル,丁目ビルディング
+    if special_building_name + "ビル" in address_data:
+        address_data = re.sub(special_building_name + "ビル", "escape_special_building_nameビル", address_data)
+    # 丁目センター
+    if special_building_name + "センター" in address_data:
+        address_data = re.sub(special_building_name + "センター", "escape_special_building_nameセンター", address_data)
+    # 丁目ホール
+    if special_building_name + "ホール" in address_data:
+        address_data = re.sub(special_building_name + "ホール", "escape_special_building_nameホール", address_data)
+    # 丁目会館
+    if special_building_name + "会館" in address_data:
+        address_data = re.sub(special_building_name + "会館", "escape_special_building_name会館", address_data)
+    # 丁目劇場
+    if special_building_name + "劇場" in address_data:
+        address_data = re.sub(special_building_name + "劇場", "escape_special_building_name劇場", address_data)
+    return address_data
+
+
+def rename_special_building_name(address_data: str, special_building_name: str) -> str:
+    # 丁目ビル,丁目ビルディング
+    if "escape_special_building_name" in address_data:
+        address_data = re.sub("escape_special_building_name", special_building_name, address_data)
+
+    return address_data

--- a/address_separator/utils/preprocess/pre/process_japanese_address_expression.py
+++ b/address_separator/utils/preprocess/pre/process_japanese_address_expression.py
@@ -25,7 +25,7 @@ def process_japanese_style_address_expression(address_data: str) -> str:
     if "番" in address_data:
         address_data = escape_special_building_name(address_data, "番")
         address_data = re.sub("番", "-", address_data)
-        address_data = escape_special_building_name(address_data, "番")
+        address_data = rename_special_building_name(address_data, "番")
     if "の" in address_data:
 
         while re.search("[0-9 ０-９]+の[0-9 ０-９]", address_data) is not None:

--- a/address_separator/utils/preprocess/pre/process_japanese_address_expression.py
+++ b/address_separator/utils/preprocess/pre/process_japanese_address_expression.py
@@ -1,7 +1,10 @@
 import re
 
 from utils.preprocess.pre.convert_connection_character import convert_connection_character
-from utils.preprocess.pre.convert_japanese_style_number_to_alabic_number import convert_japanese_style_number_to_alabic_number
+from utils.preprocess.pre.convert_japanese_style_number_to_alabic_number import (
+    convert_japanese_style_number_to_alabic_number,
+)
+from utils.preprocess.pre.fix_special_building_name import escape_special_building_name, rename_special_building_name
 
 
 def process_japanese_style_address_expression(address_data: str) -> str:
@@ -12,11 +15,17 @@ def process_japanese_style_address_expression(address_data: str) -> str:
     detail: 丁目, 番, 番地 という日本語表現を - に変換する処理を行う
     """
     if "丁目" in address_data:
+        address_data = escape_special_building_name(address_data, "丁目")
         address_data = re.sub("丁目", "-", address_data)
+        address_data = rename_special_building_name(address_data, "丁目")
     if "番地" in address_data:
+        address_data = escape_special_building_name(address_data, "番地")
         address_data = re.sub("番地", "-", address_data)
+        address_data = rename_special_building_name(address_data, "番地")
     if "番" in address_data:
+        address_data = escape_special_building_name(address_data, "番")
         address_data = re.sub("番", "-", address_data)
+        address_data = escape_special_building_name(address_data, "番")
     if "の" in address_data:
 
         while re.search("[0-9 ０-９]+の[0-9 ０-９]", address_data) is not None:

--- a/address_separator/utils/preprocess/pre/process_japanese_address_expression.py
+++ b/address_separator/utils/preprocess/pre/process_japanese_address_expression.py
@@ -12,7 +12,7 @@ def process_japanese_style_address_expression(address_data: str) -> str:
     detail: 丁目, 番, 番地 という日本語表現を - に変換する処理を行う
     """
     if "丁目" in address_data:
-        pass
+        address_data = re.sub("丁目", "-", address_data)
     if "番地" in address_data:
         address_data = re.sub("番地", "-", address_data)
     if "番" in address_data:

--- a/address_separator/utils/reformat/output_data_shaping.py
+++ b/address_separator/utils/reformat/output_data_shaping.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 from typing import Match, Union

--- a/address_separator/utils/split/pullOutCityField.py
+++ b/address_separator/utils/split/pullOutCityField.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from utils.extract.city import extract_city
 
 

--- a/address_separator/utils/split/pullOutDistrictField.py
+++ b/address_separator/utils/split/pullOutDistrictField.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def pull_out_district_field(non_town_address_data: str) -> tuple[str, str]:
     """_summary_
 

--- a/address_separator/utils/split/pullOutPrefectureField.py
+++ b/address_separator/utils/split/pullOutPrefectureField.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from utils.extract.prefecture import extract_prefecture
 
 

--- a/address_separator/utils/split/pullOutTownField.py
+++ b/address_separator/utils/split/pullOutTownField.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from utils.extract.town import extract_town
 
 

--- a/address_separator/utils/split/splitByAddressField.py
+++ b/address_separator/utils/split/splitByAddressField.py
@@ -59,7 +59,7 @@ def split_by_address_field(formatted_address_data_array: list[str], CSV_DATA: pd
     splitted_address_data_dictionaries["house_number"] = house_numbers
 
     # check 不正なデータが存在しないかどうかを確認
-    caution: list = utils.extract.detail.check.check.check(splitted_address_data_dictionaries)
+    caution: list = utils.extract.detail.check.check.check(splitted_address_data_dictionaries, others_tail)
 
     # データ整形＋分裂してしまったデータを統合整理
     manipulated_others_tail = utils.extract.detail.manipulate.manipulate(

--- a/address_separator/utils/split/splitByAddressField.py
+++ b/address_separator/utils/split/splitByAddressField.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pandas as pd
 import utils.extract.detail.building_detail
 import utils.extract.detail.check.caution
@@ -40,7 +42,9 @@ def split_by_address_field(formatted_address_data_array: list[str], CSV_DATA: pd
         non_prefecture_address_data_array, splitted_address_data_dictionaries
     )
 
-    non_town_address_data: list[str] = pull_out_town_field(non_city_address_data_array, splitted_address_data_dictionaries)
+    non_town_address_data: list[str] = pull_out_town_field(
+        non_city_address_data_array, splitted_address_data_dictionaries
+    )
 
     district_data = utils.extract.district.extract_district(non_town_address_data)
     splitted_address_data_dictionaries["district"] = district_data[0]
@@ -58,7 +62,9 @@ def split_by_address_field(formatted_address_data_array: list[str], CSV_DATA: pd
     caution: list = utils.extract.detail.check.check.check(splitted_address_data_dictionaries)
 
     # データ整形＋分裂してしまったデータを統合整理
-    manipulated_others_tail = utils.extract.detail.manipulate.manipulate(splitted_address_data_dictionaries, others_tail)
+    manipulated_others_tail = utils.extract.detail.manipulate.manipulate(
+        splitted_address_data_dictionaries, others_tail
+    )
 
     # ビルや建物情報の詳細を取得
     splitted_address_data_dictionaries[


### PR DESCRIPTION
# Refactoring version `2.1.2` -> `2.1.3`
## Description
- [`from __future__ import annotations`の追加](https://github.com/okoge-kaz/address_separator/commit/68995ffccd5001c4ed5ed8d62b7d9266dcaacaf4)
- [`丁目`についても`-`に変換されるようにした](https://github.com/okoge-kaz/address_separator/commit/ca0f5c912f44bbd8e7eec4c12f5872f28feef64b)
-  [例外( `八幡`、 `八山`、 `八事`、 `一つ山`、`三旺`)への処理追加](https://github.com/okoge-kaz/address_separator/commit/fd206923874dcaf3c717e00ce582f927f19ae9a1)
-  [その他例外(`愛知県名古屋市天白区天白町平針黒石２８４５平針住宅14-24`等)についての処理の追加](https://github.com/okoge-kaz/address_separator/commit/02767c5e394fbb61765f570cd318f92acdb233c3). 詳しくは[こちら](https://senkyo-inc.slack.com/archives/C037HU6GW20/p1651954451213969)を参照
- [上記変更に伴う`output.csv`の変化](https://github.com/okoge-kaz/address_separator/commit/73c9b631bba082da34a392db63c36222874e67b1)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactoring 

## How Has This Been Tested?

例外ケースを追加したため、出力ファイルは変化する。

例外ケース以外が変更されていないことを確認するために [check_output_csv_file](https://github.com/haruboring/check_output_csv_file)を利用し、確認作業を行なった。

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings